### PR TITLE
fix: synthetic event order 

### DIFF
--- a/src/platform_impl/linux/x11/event_processor.rs
+++ b/src/platform_impl/linux/x11/event_processor.rs
@@ -1212,6 +1212,7 @@ impl<T: 'static> EventProcessor<T> {
         }
     }
 
+    // Update modifiers state and emit key events based on which keys are currently pressed.
     fn handle_pressed_keys<F>(
         wt: &super::EventLoopWindowTarget<T>,
         window_id: crate::window::WindowId,
@@ -1225,19 +1226,17 @@ impl<T: 'static> EventProcessor<T> {
     {
         let device_id = mkdid(util::VIRTUAL_CORE_KEYBOARD);
 
-        // Update modifiers state and emit key events based on which keys are currently pressed.
+        // store non modifier keys so we can handle them after the modifiers
+        let mut non_modifier_keys: Vec<u32> = Vec::new();
+
+        // handle modifiers and store non modifiers
         for keycode in wt
             .xconn
             .query_keymap()
             .into_iter()
             .filter(|k| *k >= KEYCODE_OFFSET)
         {
-            let mut ker = kb_state.process_key_event((keycode - KEYCODE_OFFSET) as u32, state);
-            let physical_key = ker.keycode();
-            let (logical_key, location) = ker.key();
-            let text = ker.text();
-            let (key_without_modifiers, _) = ker.key_without_modifiers();
-            let text_with_all_modifiers = ker.text_with_all_modifiers();
+            let keycode = keycode as u32;
 
             if let Some(modifier) = mod_keymap.get_modifier(keycode as ffi::KeyCode) {
                 let old_modifiers = device_mod_state.modifiers();
@@ -1254,7 +1253,19 @@ impl<T: 'static> EventProcessor<T> {
                         event: WindowEvent::ModifiersChanged(device_mod_state.modifiers()),
                     });
                 }
+            } else {
+                non_modifier_keys.push(keycode);
             }
+        }
+
+        // handle non modifiers
+        for keycode in non_modifier_keys {
+            let mut ker = kb_state.process_key_event(keycode - KEYCODE_OFFSET as u32, state);
+            let physical_key = ker.keycode();
+            let (logical_key, location) = ker.key();
+            let text = ker.text();
+            let (key_without_modifiers, _) = ker.key_without_modifiers();
+            let text_with_all_modifiers = ker.text_with_all_modifiers();
 
             callback(Event::WindowEvent {
                 window_id,


### PR DESCRIPTION
This patch addresses an issue with Gnome/X11 focus handling.

Given Gnomes "Pointer Location - press CTRL to highlight the pointer"
feature is enabled, Gnome will unfocus and refocus the currently active
window whenever CTRL is pressed, e.g. when issuing a CTRL-s. When the
window is refocussed, the keys CTRL and s are reported as pressed, so
winit can report them as synthetic key events. In order to report a
proper CTRL key combination to the app though, winit needs to first
report any modifier keys (in this case CTRL) and afterwards any other
keys. This patch ensures the proper order while reporting synthetic key
events.