### PR TITLE
Fix deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - On macOS, initialize the Menu Bar with minimal defaults. (Can be prevented using `enable_default_menu_creation`)
 - On macOS, change the default behavior for first click when the window was unfocused. Now the window becomes focused and then emits a `MouseInput` event on a "first mouse click".
 - Implement mint (math interoperability standard types) conversions (under feature flag `mint`).
+- On Windows, fix bug causing deadlocks when resizing or moving windows
 
 # 0.24.0 (2020-12-09)
 

--- a/src/platform_impl/windows/event_loop.rs
+++ b/src/platform_impl/windows/event_loop.rs
@@ -7,7 +7,9 @@ use std::{
     cell::Cell,
     collections::VecDeque,
     marker::PhantomData,
-    mem, panic, ptr,
+    mem,
+    mem::MaybeUninit,
+    panic, ptr,
     rc::Rc,
     sync::{
         mpsc::{self, Receiver, Sender},
@@ -861,10 +863,26 @@ unsafe fn public_window_callback_inner<T: 'static>(
             return;
         }
         let events = {
+            let mut next_msg = MaybeUninit::uninit();
+            let peek_retval = unsafe {
+                winuser::PeekMessageW(
+                    next_msg.as_mut_ptr(),
+                    window,
+                    winuser::WM_KEYFIRST,
+                    winuser::WM_KEYLAST,
+                    winuser::PM_NOREMOVE,
+                )
+            };
+            let next_msg = (peek_retval != 0).then(|| next_msg.assume_init());
             let mut window_state = subclass_input.window_state.lock();
-            window_state
-                .key_event_builder
-                .process_message(window, msg, wparam, lparam, &mut result)
+            window_state.key_event_builder.process_message(
+                window,
+                msg,
+                wparam,
+                lparam,
+                &next_msg,
+                &mut result,
+            )
         };
         for event in events {
             subclass_input.send_event(Event::WindowEvent {


### PR DESCRIPTION
On Windows, calling PeekMessage inside the message handling function can cause reentrancy, which in turn causes deadlocks. This is especially noticeable when moving and resizing the window.

So in order to fix this, PeekMessage was removed to the outside of process_message.

I have been running this for a few months now, and everything seems to be stable. Before I made the changes I had quite frequent hangs, especially when using either PowerToys fancy zones, or even more with the nog window manager. However, that was on Windows 10 and a slower computer than I now have, and I tried to reproduce it again without my fixes and only managed to do it once, after very many tries, so the bug might not be that frequent on every system.

There has been other reports about similar things, but I'm not sure if the cause is the same, for example
https://github.com/neovide/neovide/issues/1014. I can't find others right now, but I think I have seen some others that could be related on the Neovide issues list.

- [x] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [x] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
