### PR TITLE
On X11, don't panic when getting EINTR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+- On X11, EINTR while polling for events no longer causes a panic. Instead it will be treated as a spurious wakeup.
+
+# 0.25.0 (2021-05-15)
+
 - **Breaking:** On macOS, replace `WindowBuilderExtMacOS::with_activation_policy` with `EventLoopExtMacOS::set_activation_policy`
 - On macOS, wait with activating the application until the application has initialized.
 - On macOS, fix creating new windows when the application has a main menu.

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -393,7 +393,11 @@ impl<T: 'static> EventLoop<T> {
             // If the XConnection already contains buffered events, we don't
             // need to wait for data on the socket.
             if !self.event_processor.poll() {
-                self.poll.poll(&mut events, timeout).unwrap();
+                if let Err(e) = self.poll.poll(&mut events, timeout) {
+                    if e.raw_os_error() != Some(libc::EINTR) {
+                        panic!("epoll returned an error: {:?}", e);
+                    }
+                }
                 events.clear();
             }
 


### PR DESCRIPTION
Fixes #1972.

- [ ] Tested on all platforms changed
- [x] Compilation warnings were addressed
- [x] `cargo fmt` has been run on this branch
- [ ] `cargo doc` builds successfully
- [x] Added an entry to `CHANGELOG.md` if knowledge of this change could be valuable to users
- [ ] Updated documentation to reflect any user-facing changes, including notes of platform-specific behavior
- [ ] Created or updated an example program if it would help users understand this functionality
- [ ] Updated [feature matrix](https://github.com/rust-windowing/winit/blob/master/FEATURES.md), if new features were added or implemented
