### PR TITLE
Backport `accepts-first-mouse` for Neovide

### DIFF
--- a/src/platform/macos.rs
+++ b/src/platform/macos.rs
@@ -120,6 +120,8 @@ pub trait WindowBuilderExtMacOS {
     fn with_resize_increments(self, increments: LogicalSize<f64>) -> WindowBuilder;
     fn with_disallow_hidpi(self, disallow_hidpi: bool) -> WindowBuilder;
     fn with_has_shadow(self, has_shadow: bool) -> WindowBuilder;
+    /// Window accepts click-through mouse events.
+    fn with_accepts_first_mouse(self, accepts_first_mouse: bool) -> WindowBuilder;
 }
 
 impl WindowBuilderExtMacOS for WindowBuilder {
@@ -177,6 +179,12 @@ impl WindowBuilderExtMacOS for WindowBuilder {
     #[inline]
     fn with_has_shadow(mut self, has_shadow: bool) -> WindowBuilder {
         self.platform_specific.has_shadow = has_shadow;
+        self
+    }
+
+    #[inline]
+    fn with_accepts_first_mouse(mut self, accepts_first_mouse: bool) -> WindowBuilder {
+        self.platform_specific.accepts_first_mouse = accepts_first_mouse;
         self
     }
 }

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -89,7 +89,7 @@ pub fn new_view(ns_window: id, accepts_first_mouse: bool) -> (IdRef, Weak<Mutex<
         modifiers: Default::default(),
         phys_modifiers: Default::default(),
         tracking_rect: None,
-        accepts_first_mouse: accepts_first_mouse,
+        accepts_first_mouse,
     };
     unsafe {
         // This is free'd in `dealloc`

--- a/src/platform_impl/macos/view.rs
+++ b/src/platform_impl/macos/view.rs
@@ -66,6 +66,7 @@ pub(super) struct ViewState {
     pub(super) modifiers: ModifiersState,
     phys_modifiers: HashSet<KeyCode>,
     tracking_rect: Option<NSInteger>,
+    accepts_first_mouse: bool,
 }
 
 impl ViewState {
@@ -74,7 +75,7 @@ impl ViewState {
     }
 }
 
-pub fn new_view(ns_window: id) -> (IdRef, Weak<Mutex<CursorState>>) {
+pub fn new_view(ns_window: id, accepts_first_mouse: bool) -> (IdRef, Weak<Mutex<CursorState>>) {
     let cursor_state = Default::default();
     let cursor_access = Arc::downgrade(&cursor_state);
     let state = ViewState {
@@ -88,6 +89,7 @@ pub fn new_view(ns_window: id) -> (IdRef, Weak<Mutex<CursorState>>) {
         modifiers: Default::default(),
         phys_modifiers: Default::default(),
         tracking_rect: None,
+        accepts_first_mouse: accepts_first_mouse,
     };
     unsafe {
         // This is free'd in `dealloc`
@@ -1174,6 +1176,11 @@ extern "C" fn wants_key_down_for_event(_this: &Object, _sel: Sel, _event: id) ->
     YES
 }
 
-extern "C" fn accepts_first_mouse(_this: &Object, _sel: Sel, _event: id) -> BOOL {
-    YES
+extern "C" fn accepts_first_mouse(this: &Object, _sel: Sel, _event: id) -> BOOL {
+    unsafe {
+        let state_ptr: *const c_void = *this.get_ivar("winitState");
+        let state = &*(state_ptr as *const ViewState);
+
+        state.accepts_first_mouse as BOOL
+    }
 }

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -72,6 +72,7 @@ pub struct PlatformSpecificWindowBuilderAttributes {
     pub resize_increments: Option<LogicalSize<f64>>,
     pub disallow_hidpi: bool,
     pub has_shadow: bool,
+    pub accepts_first_mouse: bool,
 }
 
 impl Default for PlatformSpecificWindowBuilderAttributes {
@@ -87,6 +88,7 @@ impl Default for PlatformSpecificWindowBuilderAttributes {
             resize_increments: None,
             disallow_hidpi: false,
             has_shadow: true,
+            accepts_first_mouse: true,
         }
     }
 }
@@ -95,7 +97,7 @@ unsafe fn create_view(
     ns_window: id,
     pl_attribs: &PlatformSpecificWindowBuilderAttributes,
 ) -> Option<(IdRef, Weak<Mutex<CursorState>>)> {
-    let (ns_view, cursor_state) = new_view(ns_window);
+    let (ns_view, cursor_state) = new_view(ns_window, pl_attribs.accepts_first_mouse);
     ns_view.non_nil().map(|ns_view| {
         if !pl_attribs.disallow_hidpi {
             ns_view.setWantsBestResolutionOpenGLSurface_(YES);


### PR DESCRIPTION
Backport https://github.com/rust-windowing/winit/pull/2457 for Neovide's fork. Here's how to enable the flag in Neovide:

```diff
diff --git a/src/window/mod.rs b/src/window/mod.rs
index 0dccb94..e1eef05 100644
--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -343,6 +343,10 @@ pub fn create_window() {
             cmd_line_settings.x11_wm_class,
         );
 
+    #[cfg(target_os = "macos")]
+    let winit_window_builder = winit_window_builder
+        .with_accepts_first_mouse(false);
+
     let windowed_context = ContextBuilder::new()
         .with_pixel_format(24, 8)
         .with_stencil_buffer(8)
```