### PR TITLE
Re-export some structs for X11

### DIFF
--- a/src/platform_impl/linux/mod.rs
+++ b/src/platform_impl/linux/mod.rs
@@ -20,9 +20,9 @@ use once_cell::sync::Lazy;
 use raw_window_handle::{RawDisplayHandle, RawWindowHandle};
 
 #[cfg(x11_platform)]
-pub use self::x11::XNotSupported;
+pub use self::x11::{XConnection, XNotSupported};
 #[cfg(x11_platform)]
-use self::x11::{ffi::XVisualInfo, util::WindowType as XWindowType, XConnection, XError};
+use self::x11::{ffi::XVisualInfo, util::WindowType as XWindowType, XError};
 #[cfg(x11_platform)]
 use crate::platform::x11::XlibErrorHook;
 use crate::{

--- a/src/platform_impl/linux/wayland/seat/keyboard/handlers.rs
+++ b/src/platform_impl/linux/wayland/seat/keyboard/handlers.rs
@@ -541,7 +541,8 @@ impl KbdHandler {
                 _ => unreachable!(),
             };
 
-            let mut ker = state.process_key_event(key + 8, key_state);
+            let keycode = key + 8;
+            let mut ker = state.process_key_event(keycode, key_state);
 
             let physical_key = ker.keycode();
             let (logical_key, location) = ker.key();
@@ -549,7 +550,7 @@ impl KbdHandler {
             let (key_without_modifiers, _) = ker.key_without_modifiers();
             let text_with_all_modifiers = ker.text_with_all_modifiers();
 
-            let repeats = unsafe { state.key_repeats(key) };
+            let repeats = unsafe { state.key_repeats(keycode) };
 
             (
                 physical_key,

--- a/src/platform_impl/linux/x11/mod.rs
+++ b/src/platform_impl/linux/x11/mod.rs
@@ -12,10 +12,9 @@ mod xdisplay;
 pub(crate) use self::{
     monitor::{MonitorHandle, VideoMode},
     window::UnownedWindow,
-    xdisplay::XConnection,
 };
 
-pub use self::xdisplay::{XError, XNotSupported};
+pub use self::xdisplay::{XConnection, XError, XNotSupported};
 
 use std::{
     cell::{Cell, RefCell},

--- a/src/platform_impl/linux/x11/util/hint.rs
+++ b/src/platform_impl/linux/x11/util/hint.rs
@@ -185,7 +185,7 @@ impl MwmHints {
     }
 }
 
-pub(crate) struct NormalHints<'a> {
+pub struct NormalHints<'a> {
     size_hints: XSmartPointer<'a, ffi::XSizeHints>,
 }
 

--- a/src/platform_impl/linux/x11/util/memory.rs
+++ b/src/platform_impl/linux/x11/util/memory.rs
@@ -2,7 +2,7 @@ use std::ops::{Deref, DerefMut};
 
 use super::*;
 
-pub(crate) struct XSmartPointer<'a, T> {
+pub struct XSmartPointer<'a, T> {
     xconn: &'a XConnection,
     pub ptr: *mut T,
 }

--- a/src/platform_impl/linux/x11/util/mod.rs
+++ b/src/platform_impl/linux/x11/util/mod.rs
@@ -49,7 +49,7 @@ where
 }
 
 #[must_use = "This request was made asynchronously, and is still in the output buffer. You must explicitly choose to either `.flush()` (empty the output buffer, sending the request now) or `.queue()` (wait to send the request, allowing you to continue to add more requests without additional round-trips). For more information, see the documentation for `util::flush_requests`."]
-pub(crate) struct Flusher<'a> {
+pub struct Flusher<'a> {
     xconn: &'a XConnection,
 }
 

--- a/src/platform_impl/linux/x11/window.rs
+++ b/src/platform_impl/linux/x11/window.rs
@@ -1319,6 +1319,11 @@ impl UnownedWindow {
     }
 
     #[inline]
+    pub fn xlib_xconnection(&self) -> Arc<XConnection> {
+        Arc::clone(&self.xconn)
+    }
+
+    #[inline]
     pub fn xlib_window(&self) -> c_ulong {
         self.xwindow
     }

--- a/src/platform_impl/linux/x11/xdisplay.rs
+++ b/src/platform_impl/linux/x11/xdisplay.rs
@@ -5,13 +5,14 @@ use crate::window::CursorIcon;
 use super::ffi;
 
 /// A connection to an X server.
-pub(crate) struct XConnection {
+pub struct XConnection {
     pub xlib: ffi::Xlib,
     /// Exposes XRandR functions from version < 1.5
     pub xrandr: ffi::Xrandr_2_2_0,
     pub xcursor: ffi::Xcursor,
     pub xinput2: ffi::XInput2,
     pub xlib_xcb: ffi::Xlib_xcb,
+    pub xrender: ffi::Xrender,
     pub display: *mut ffi::Display,
     pub x11_fd: c_int,
     pub latest_error: Mutex<Option<XError>>,
@@ -32,6 +33,7 @@ impl XConnection {
         let xrandr = ffi::Xrandr_2_2_0::open()?;
         let xinput2 = ffi::XInput2::open()?;
         let xlib_xcb = ffi::Xlib_xcb::open()?;
+        let xrender = ffi::Xrender::open()?;
 
         unsafe { (xlib.XInitThreads)() };
         unsafe { (xlib.XSetErrorHandler)(error_handler) };
@@ -54,6 +56,7 @@ impl XConnection {
             xcursor,
             xinput2,
             xlib_xcb,
+            xrender,
             display,
             x11_fd: fd,
             latest_error: Mutex::new(None),


### PR DESCRIPTION
`XConnection` was marked internal by https://github.com/rust-windowing/winit/commit/490abcad14cb698a8e253be6f33ecc4211002d9f, which broke `x11` part of `glutin`.