### PR TITLE
Cherry-pick from parent repo PR to fix macOS menu bar in fullscreen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - On X11, EINTR while polling for events no longer causes a panic. Instead it will be treated as a spurious wakeup.
 - On X11, if RANDR based scale factor is higher than 20 reset it to 1
+- On macOS, fix an issue that prevented the menu bar from showing in borderless fullscreen mode.
 
 # 0.25.0 (2021-05-15)
 

--- a/src/platform_impl/macos/window.rs
+++ b/src/platform_impl/macos/window.rs
@@ -284,7 +284,10 @@ pub struct SharedState {
     is_simple_fullscreen: bool,
     pub saved_style: Option<NSWindowStyleMask>,
     /// Presentation options saved before entering `set_simple_fullscreen`, and
-    /// restored upon exiting it
+    /// restored upon exiting it. Also used when transitioning from Borderless to
+    /// Exclusive fullscreen in `set_fullscreen` because we need to disable the menu
+    /// bar in exclusive fullscreen but want to restore the original options when
+    /// transitioning back to borderless fullscreen.
     save_presentation_opts: Option<NSApplicationPresentationOptions>,
     pub saved_desktop_display_mode: Option<(CGDisplay, CGDisplayMode)>,
 }
@@ -793,6 +796,15 @@ impl UnownedWindow {
 
             let mut fade_token = ffi::kCGDisplayFadeReservationInvalidToken;
 
+            if matches!(old_fullscreen, Some(Fullscreen::Borderless(_))) {
+                unsafe {
+                    let app = NSApp();
+                    trace!("Locked shared state in `set_fullscreen`");
+                    let mut shared_state_lock = self.shared_state.lock().unwrap();
+                    shared_state_lock.save_presentation_opts = Some(app.presentationOptions_());
+                }
+            }
+
             unsafe {
                 // Fade to black (and wait for the fade to complete) to hide the
                 // flicker from capturing the display and switching display mode
@@ -843,7 +855,6 @@ impl UnownedWindow {
         trace!("Locked shared state in `set_fullscreen`");
         let mut shared_state_lock = self.shared_state.lock().unwrap();
         shared_state_lock.fullscreen = fullscreen.clone();
-        trace!("Unlocked shared state in `set_fullscreen`");
 
         INTERRUPT_EVENT_LOOP_EXIT.store(true, Ordering::SeqCst);
 
@@ -884,16 +895,42 @@ impl UnownedWindow {
                 // of the menu bar, and this looks broken, so we must make sure
                 // that the menu bar is disabled. This is done in the window
                 // delegate in `window:willUseFullScreenPresentationOptions:`.
+                let app = NSApp();
+                trace!("Locked shared state in `set_fullscreen`");
+                shared_state_lock.save_presentation_opts = Some(app.presentationOptions_());
+
+                let presentation_options =
+                    NSApplicationPresentationOptions::NSApplicationPresentationFullScreen
+                        | NSApplicationPresentationOptions::NSApplicationPresentationHideDock
+                        | NSApplicationPresentationOptions::NSApplicationPresentationHideMenuBar;
+                app.setPresentationOptions_(presentation_options);
+
                 let () = msg_send![*self.ns_window, setLevel: ffi::CGShieldingWindowLevel() + 1];
             },
             (
                 &Some(Fullscreen::Exclusive(RootVideoMode { ref video_mode })),
                 &Some(Fullscreen::Borderless(_)),
             ) => unsafe {
+                let presentation_options =
+                    shared_state_lock.save_presentation_opts.unwrap_or_else(|| {
+                        NSApplicationPresentationOptions::NSApplicationPresentationFullScreen
+                        | NSApplicationPresentationOptions::NSApplicationPresentationAutoHideDock
+                        | NSApplicationPresentationOptions::NSApplicationPresentationAutoHideMenuBar
+                    });
+                NSApp().setPresentationOptions_(presentation_options);
+
                 util::restore_display_mode_async(video_mode.monitor().inner.native_identifier());
+
+                // Restore the normal window level following the Borderless fullscreen
+                // `CGShieldingWindowLevel() + 1` hack.
+                let () = msg_send![
+                    *self.ns_window,
+                    setLevel: ffi::NSWindowLevel::NSNormalWindowLevel
+                ];
             },
             _ => INTERRUPT_EVENT_LOOP_EXIT.store(false, Ordering::SeqCst),
-        }
+        };
+        trace!("Unlocked shared state in `set_fullscreen`");
     }
 
     #[inline]


### PR DESCRIPTION
Fixes neovide/neovide#1062.

This PR cherry-picks the [merge-commit](https://github.com/rust-windowing/winit/commit/f2de8475fc4703d03a2ecc2cda627b017202e623) from rust-windowing/winit#2053 that fixes an issue where the macOS menu bar would not be available when a window was displayed fullscreen. This made it impossible (or at the very least, difficult) to un-fullscreen said window.

I have modified the commit slightly to properly update the CHANGELOG.md of this repository. Otherwise the commit is untouched.

All tests both on this repository and on [`neovide/neovide`](https://github.com/neovide/neovide) pass with these changes.